### PR TITLE
Enable debugging

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ var oa = new OAuth2({
   accessTokenUrl: "/oauth/token" // optional,
   timeout: 20000, // optional
   rejectUnauthorized: true // optional
+  verbose: false // optional (will print debug information)
 });
 oa.getAccessToken(callback)
 ```
@@ -48,6 +49,7 @@ var rest = new Rest({
   rejectUnauthorized: true, // optional
   oauth_host: "auth.sphere.io" // optional (used when retrieving the access_token internally)
   user_agent: 'my client v0.1' // optional
+  verbose: false // optional (will print debug information)
 });
 
 rest.GET(resource, callback)

--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
   },
   "dependencies": {
     "request": "~2.33.0",
-    "underscore": "~1.5.2"
+    "underscore": "~1.5.2",
+    "npmlog": "~0.0.6"
   },
   "devDependencies": {
     "coveralls": "~2.7.0",

--- a/src/coffee/debug.coffee
+++ b/src/coffee/debug.coffee
@@ -1,0 +1,14 @@
+log = require('npmlog')
+
+module.exports = class
+
+  @http: (isActive, response)->
+    if isActive
+      log.http('CONNECT', 'request ====================>')
+      log.http('URI', response.request.uri)
+      log.http('Method', response.request.method)
+      log.http('Headers', response.request.headers)
+      log.http('CONNECT', 'response ====================>')
+      log.http('Status', response.statusCode)
+      log.http('Headers', response.headers)
+      log.http('Body', response.body)

--- a/src/coffee/oauth2.coffee
+++ b/src/coffee/oauth2.coffee
@@ -1,6 +1,7 @@
 _ = require("underscore")._
 querystring = require('querystring')
 request = require('request')
+debug = require('./debug')
 
 class OAuth2
 
@@ -18,6 +19,7 @@ class OAuth2
       accessTokenUrl: opts.accessTokenUrl or "/oauth/token"
       timeout: opts.timeout or 20000
       rejectUnauthorized: rejectUnauthorized
+      verbose: opts.verbose or false
     return
 
   getAccessToken: (callback)->
@@ -36,7 +38,12 @@ class OAuth2
       timeout: @_options.timeout
       rejectUnauthorized: @_options.rejectUnauthorized
 
-    request request_options, callback
+    @_doRequest request_options, callback
+
+  _doRequest: (options, callback)->
+    request options, (e, r, b)=>
+      debug.http(@_options.verbose, r)
+      callback(e, r, b)
 
 ###
 Exports object

--- a/src/coffee/rest.coffee
+++ b/src/coffee/rest.coffee
@@ -1,6 +1,7 @@
 _ = require("underscore")._
 request = require("request")
 OAuth2 = require("./oauth2")
+debug = require('./debug')
 
 class Rest
 
@@ -19,6 +20,7 @@ class Rest
       access_token: opts.access_token or undefined
       timeout: opts.timeout or 20000
       rejectUnauthorized: rejectUnauthorized
+      verbose: opts.verbose or false
       headers:
         'User-Agent': userAgent
     @_options.uri = "https://#{@_options.host}/#{@_options.config.project_key}"
@@ -93,7 +95,10 @@ class Rest
 
     _req(0)
 
-  _doRequest: (options, callback)-> request options, callback
+  _doRequest: (options, callback)->
+    request options, (e, r, b)=>
+      debug.http(@_options.verbose, r)
+      callback(e, r, b)
 
 ###
 Exports object

--- a/src/spec/debug.spec.coffee
+++ b/src/spec/debug.spec.coffee
@@ -1,0 +1,24 @@
+log = require('npmlog')
+debug = require('../lib/debug')
+
+describe 'Debug', ->
+
+  beforeEach ->
+    @response =
+      statusCode: 200
+      headers: {}
+      body: ''
+      request:
+        uri: {}
+        method: 'GET'
+        headers: {}
+
+    spyOn(log, 'http')
+
+  it 'should log request', ->
+    debug.http(true, @response)
+    expect(log.http).toHaveBeenCalled()
+
+  it 'should not log request (if no verbose option is given)', ->
+    debug.http(false, @response)
+    expect(log.http).not.toHaveBeenCalled()

--- a/src/spec/oauth2.spec.coffee
+++ b/src/spec/oauth2.spec.coffee
@@ -12,6 +12,7 @@ describe "OAuth2", ->
     expect(oa._options.accessTokenUrl).toBe "/oauth/token"
     expect(oa._options.timeout).toBe 20000
     expect(oa._options.rejectUnauthorized).toBe true
+    expect(oa._options.verbose).toBe false
 
   it "should throw error if no credentials are given", ->
     oa = -> new OAuth2
@@ -47,3 +48,9 @@ describe "OAuth2", ->
       config: Config.prod
       rejectUnauthorized: false
     expect(oa._options.rejectUnauthorized).toBe false
+
+  it "should pass 'verbose' option", ->
+    oa = new OAuth2
+      config: Config.prod
+      verbose: true
+    expect(oa._options.verbose).toBe true

--- a/src/spec/rest.spec.coffee
+++ b/src/spec/rest.spec.coffee
@@ -15,6 +15,7 @@ describe "Rest", ->
     expect(rest._options.timeout).toBe 20000
     expect(rest._options.rejectUnauthorized).toBe true
     expect(rest._options.headers["User-Agent"]).toBe "sphere-node-connect"
+    expect(rest._options.verbose).toBe false
 
   it "should throw error if no credentials are given", ->
     rest = -> new Rest
@@ -62,6 +63,12 @@ describe "Rest", ->
       config: Config
       user_agent: "commercetools"
     expect(rest._options.headers["User-Agent"]).toBe "commercetools"
+
+  it "should pass 'verbose' option", ->
+    rest = new Rest
+      config: Config
+      verbose: true
+    expect(rest._options.verbose).toBe true
 
 describe "Rest requests", ->
 


### PR DESCRIPTION
@svenmueller @hajoeichler please have a look.

My idea is:
- you can activate the **verbose** mode by passing the option `verbose` when instantiating a `OAuth2` or `Rest` object
- the response of [`request`](https://github.com/mikeal/request) containing info about request/response will be logged using the `npmlog` package

We can then apply the same configuration to the other packages (e.g.: node-client, node-cli). As they will all "share" the same configuration it will be just a matter of setting the flag to enabling debug.

This is what it will look like

``` bash
http CONNECT request ====================>
http URI { protocol: 'https:',
http URI   slashes: true,
http URI   auth: 'S6AD07quPeeTfRoOHXdTx2NZ:7d3xSWTN5jQJNpnRnMLd4qICmfahGPka',
http URI   host: 'auth.sphere.io',
http URI   port: 443,
http URI   hostname: 'auth.sphere.io',
http URI   hash: null,
http URI   search: null,
http URI   query: null,
http URI   pathname: '/oauth/token',
http URI   path: '/oauth/token',
http URI   href: 'https://S6AD07quPeeTfRoOHXdTx2NZ:7d3xSWTN5jQJNpnRnMLd4qICmfahGPka@auth.sphere.io/oauth/token' }
http Method POST
http Headers { 'Content-Type': 'application/x-www-form-urlencoded',
http Headers   'Content-Length': 59,
http Headers   authorization: 'Basic UzZBRDA3cXVQZWVUZlJvT0hYZFR4Mk5aOjdkM3hTV1RONWpRSk5wblJuTUxkNHFJQ21mYWhHUGth' }
http CONNECT response ====================>
http Status 200
http Headers { server: 'nginx',
http Headers   date: 'Sun, 09 Feb 2014 21:45:47 GMT',
http Headers   'content-type': 'application/json; charset=utf-8',
http Headers   'transfer-encoding': 'chunked',
http Headers   connection: 'keep-alive',
http Headers   pragma: 'no-cache',
http Headers   'cache-control': 'no-store',
http Headers   'x-served-by': 'app3.sphere.prod.commercetools.de',
http Headers   'x-served-config': 'sphere-auth-ws-1.0' }
http Body {"access_token":"0YK4ncUCyOVInKWz_a2WXoB5uI8oSmtW","token_type":"Bearer","expires_in":172800,"scope":"manage_project:nicola"}
```
